### PR TITLE
Install from fsspec[http] extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages = find:
 include_package_data = True
 install_requires =
     dvc
-    fsspec
+    fsspec[http]
     aiohttp-retry>=2.5.0
 
 [options.extras_require]


### PR DESCRIPTION
`http` extra has `aiohttp` dependency specified. Currently, it is being specified in dvc itself.
See https://github.com/iterative/dvc/blob/b376044c4567a927b9f4d2820358c9392dfba226/setup.cfg#L65.

We'll likely need a version bump of dvc-http to get it removed in dvc after this is merged.