### PR TITLE
workflows: testing: install required extras for dvc

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,7 +74,7 @@ jobs:
       run: |
         pip install --upgrade pip setuptools wheel
         pip install -e ".[tests]"
-        pip install git+https://github.com/iterative/dvc
+        pip install --install-option="--extras-require=testing" git+https://github.com/iterative/dvc
     - name: setup git
       run: |
         git config --global user.email "dvctester@example.com"


### PR DESCRIPTION
Proposed PR should fix recently failing test builds.
I don't think this is a proper fix.
It seems to me that proper dvc should be installed when running:
https://github.com/iterative/dvc-http/blob/0bcfc8512c99a4969d609fbfdd4ac2eba61b9677/.github/workflows/tests.yaml#L35

which includes required extra: 

https://github.com/iterative/dvc-http/blob/0bcfc8512c99a4969d609fbfdd4ac2eba61b9677/setup.cfg#L37
Hovewer, closer inspection yields that pip is unable to resolve the extra during `dvc-http` installation:

```
21538 Given no hashes to check 0 links for project 'dvc-render': discarding no candidates
21539 WARNING: dvc 2.26.1 does not provide the extra 'testing'
21540 WARNING: dvc 2.26.0 does not provide the extra 'testing'
21541 WARNING: dvc 2.25.0 does not provide the extra 'testing'
21542 WARNING: dvc 2.24.0 does not provide the extra 'testing'
21543 Given no hashes to check 0 links for project 'dvc-data': discarding no candidates
21544 WARNING: dvc 2.23.0 does not provide the extra 'testing'
21545 WARNING: dvc 2.22.1 does not provide the extra 'testing'
21546 WARNING: dvc 2.22.0 does not provide the extra 'testing'
21547 WARNING: dvc 2.21.3 does not provide the extra 'testing'
21548 WARNING: dvc 2.21.2 does not provide the extra 'testing'    
21549 WARNING: dvc 2.21.1 does not provide the extra 'testing'
21550 WARNING: dvc 2.21.0 does not provide the extra 'testing'
21551 WARNING: dvc 2.20.1 does not provide the extra 'testing'
21552 WARNING: dvc 2.20.0 does not provide the extra 'testing'
21553 WARNING: dvc 2.19.0 does not provide the extra 'testing'
21554 WARNING: dvc 2.18.1 does not provide the extra 'testing'
21555 Given no hashes to check 0 links for project 'dvc-data': discarding no candidates
21556 WARNING: dvc 2.18.0 does not provide the extra 'testing'
```

Maybe its due to the fact that we exclude `testing` here:

https://github.com/iterative/dvc/blob/ba1ab860784465beba1302a5d740b7c033251cea/setup.cfg#L143-L148

@efiop is there a reason why we install DVC again in the workflow? Or is it leftover from the initial commit?