### PR TITLE
read timeout values from config (or fallback to default)

### DIFF
--- a/dvc_http/__init__.py
+++ b/dvc_http/__init__.py
@@ -121,7 +121,7 @@ class HTTPFileSystem(FileSystem):
             attempts=self.SESSION_RETRIES,
             factor=self.SESSION_BACKOFF_FACTOR,
             max_timeout=self.REQUEST_TIMEOUT,
-            exceptions=[aiohttp.ClientError],
+            exceptions={aiohttp.ClientError},
         )
 
         # The default timeout for the aiohttp is 300 seconds


### PR DESCRIPTION
Timeouts can be configured using the `connect_timeout`, `sock_connect_timeout` and `sock_read_timeout" kwargs.

Documentation for these can be found in the aiohttp docs: https://docs.aiohttp.org/en/stable/client_reference.html?highlight=clienttimeout#clienttimeout.

Setting these to `0` or `None` disables the timeouts entirely.


closes #15 