### PR TITLE
fix get_client

### DIFF
--- a/dvc_http/__init__.py
+++ b/dvc_http/__init__.py
@@ -113,19 +113,19 @@ class HTTPFileSystem(FileSystem):
         # data blobs. We remove the total timeout, and only limit the time
         # that is spent when connecting to the remote server and waiting
         # for new data portions.
-        connect_timeout = kwargs.get("connect_timeout", self.REQUEST_TIMEOUT)
+        connect_timeout = kwargs.pop("connect_timeout", self.REQUEST_TIMEOUT)
         kwargs["timeout"] = aiohttp.ClientTimeout(
             total=None,
             connect=connect_timeout,
             sock_connect=connect_timeout,
-            sock_read=kwargs.get("read_timeout", self.REQUEST_TIMEOUT),
+            sock_read=kwargs.pop("read_timeout", self.REQUEST_TIMEOUT),
         )
 
         kwargs["connector"] = aiohttp.TCPConnector(
             # Force cleanup of closed SSL transports.
             # See https://github.com/iterative/dvc/issues/7414
             enable_cleanup_closed=True,
-            ssl=make_context(kwargs.get("ssl_verify")),
+            ssl=make_context(kwargs.pop("ssl_verify", None)),
         )
 
         return ReadOnlyRetryClient(**kwargs)

--- a/dvc_http/tests/test_config.py
+++ b/dvc_http/tests/test_config.py
@@ -1,0 +1,91 @@
+import ssl
+
+from dvc.fs import HTTPFileSystem
+
+
+def test_public_auth_method(dvc):
+    config = {
+        "url": "http://example.com/",
+        "path": "file.html",
+        "user": "",
+        "password": "",
+    }
+
+    fs = HTTPFileSystem(**config)
+
+    assert "auth" not in fs.fs_args["client_kwargs"]
+    assert "headers" not in fs.fs_args
+
+
+def test_basic_auth_method(dvc):
+    user = "username"
+    password = "password"
+    config = {
+        "url": "http://example.com/",
+        "path": "file.html",
+        "auth": "basic",
+        "user": user,
+        "password": password,
+    }
+
+    fs = HTTPFileSystem(**config)
+
+    assert fs.fs_args["client_kwargs"]["auth"].login == user
+    assert fs.fs_args["client_kwargs"]["auth"].password == password
+
+
+def test_custom_auth_method(dvc):
+    header = "Custom-Header"
+    password = "password"
+    config = {
+        "url": "http://example.com/",
+        "path": "file.html",
+        "auth": "custom",
+        "custom_auth_header": header,
+        "password": password,
+    }
+
+    fs = HTTPFileSystem(**config)
+
+    headers = fs.fs_args["headers"]
+    assert header in headers
+    assert headers[header] == password
+
+
+def test_ssl_verify_disable(dvc):
+    config = {
+        "url": "http://example.com/",
+        "path": "file.html",
+        "ssl_verify": False,
+    }
+
+    fs = HTTPFileSystem(**config)
+    assert not fs.fs_args["client_kwargs"]["connector"]._ssl
+
+
+def test_ssl_verify_custom_cert(dvc, mocker):
+    mocker.patch("ssl.SSLContext.load_verify_locations")
+    config = {
+        "url": "http://example.com/",
+        "path": "file.html",
+        "ssl_verify": "/path/to/custom/cabundle.pem",
+    }
+
+    fs = HTTPFileSystem(**config)
+
+    assert isinstance(
+        fs.fs_args["client_kwargs"]["connector"]._ssl, ssl.SSLContext
+    )
+
+
+def test_http_method(dvc):
+    config = {
+        "url": "http://example.com/",
+        "path": "file.html",
+    }
+
+    fs = HTTPFileSystem(**config, method="PUT")
+    assert fs.upload_method == "PUT"
+
+    fs = HTTPFileSystem(**config, method="POST")
+    assert fs.upload_method == "POST"

--- a/dvc_http/tests/test_config.py
+++ b/dvc_http/tests/test_config.py
@@ -3,7 +3,7 @@ import ssl
 from dvc.fs import HTTPFileSystem
 
 
-def test_public_auth_method(dvc):
+def test_public_auth_method():
     config = {
         "url": "http://example.com/",
         "path": "file.html",
@@ -17,7 +17,7 @@ def test_public_auth_method(dvc):
     assert "headers" not in fs.fs_args
 
 
-def test_basic_auth_method(dvc):
+def test_basic_auth_method():
     user = "username"
     password = "password"
     config = {
@@ -34,7 +34,7 @@ def test_basic_auth_method(dvc):
     assert fs.fs_args["client_kwargs"]["auth"].password == password
 
 
-def test_custom_auth_method(dvc):
+def test_custom_auth_method():
     header = "Custom-Header"
     password = "password"
     config = {
@@ -52,7 +52,7 @@ def test_custom_auth_method(dvc):
     assert headers[header] == password
 
 
-def test_ssl_verify_disable(dvc):
+def test_ssl_verify_disable():
     config = {
         "url": "http://example.com/",
         "path": "file.html",
@@ -63,7 +63,7 @@ def test_ssl_verify_disable(dvc):
     assert not fs.fs_args["client_kwargs"]["connector"]._ssl
 
 
-def test_ssl_verify_custom_cert(dvc, mocker):
+def test_ssl_verify_custom_cert(mocker):
     mocker.patch("ssl.SSLContext.load_verify_locations")
     config = {
         "url": "http://example.com/",
@@ -78,7 +78,7 @@ def test_ssl_verify_custom_cert(dvc, mocker):
     )
 
 
-def test_http_method(dvc):
+def test_http_method():
     config = {
         "url": "http://example.com/",
         "path": "file.html",


### PR DESCRIPTION
- do not pass over timeout/ssl_verify kwargs to client in `get_client`
- include config tests (moved from https://github.com/iterative/dvc/commit/a0c781a676d2f70dbe2cdaefec6497492957ea8b)
