### PR TITLE
deps: remove dvc dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ zip_safe = False
 packages = find:
 include_package_data = True
 install_requires =
-    dvc
     fsspec[http]
     aiohttp-retry>=2.5.0
 


### PR DESCRIPTION
dvc-http does not really depend on dvc. This also removes a circular dependency 

closes https://github.com/iterative/dvc/issues/8897