### PR TITLE
Migrate from PyPI tokens to Trusted Publishers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   pip:
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -32,5 +36,3 @@ jobs:
     - name: Publish packages to PyPI
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers#using-trusted-publishing-with-github-actions